### PR TITLE
Forest Code Edits

### DIFF
--- a/MG analyses.Rmd
+++ b/MG analyses.Rmd
@@ -60,11 +60,11 @@ plot(shoots.per.disc ~ no.sites, data = mg.spring2017.1month.den.Poly5)
 
 ##3poly
 ###Data management
-mg.spring2017.1month.den.Poly3 <- subset(mg.spring2017.1month.den, identity == "Niles" | identity == "Poly 3" | identity == "West" | identity == "Nahant" )
+mg.spring2017.1month.den.Poly3 <- subset(mg.spring2017.1month.den, identity == "Niles" | identity == "Poly 3" | identity == "West" | identity == "Lynn" )
 
 ###model
 model.3poly = lm(no.shoots ~ no.sites + identity + no.discs, data=mg.spring2017.1month.den.Poly3)
-anova(model.3poly) #no.discs and identity --> significant, no overyielding
+anova(model.3poly) #no.discs, no.sites, and identity --> significant, no overyielding
 plot(shoots.per.disc ~ identity, data = mg.spring2017.1month.den.Poly3, ylim = c(0,15))
 plot(shoots.per.disc ~ no.sites, data = mg.spring2017.1month.den.Poly3, ylim = c(0,15))
 ```
@@ -77,7 +77,7 @@ anova(model)
 
 #percent cover - differences by diversity (parsed between 3 and 5), identity; number of discs as covariate; transect removed
 model = lm(percent.cover ~ no.sites + identity + no.discs, data = mg.spring2017.1month)
-anova(model) #why is identity excluded from output?
+anova(model) #why is identity excluded from output?       ##########???################
 ```
 
 ##Canopy height
@@ -110,11 +110,11 @@ plot(canopy.height ~ identity, data = mg.spring2017.1month.ch.Poly5)
 
 ##3poly
 ###Data management
-mg.spring2017.1month.ch.Poly3 <- subset(mg.spring2017.1month.ch, identity == "Niles" | identity == "Poly 3" | identity == "West" | identity == "Nahant" )
+mg.spring2017.1month.ch.Poly3 <- subset(mg.spring2017.1month.ch, identity == "Niles" | identity == "Poly 3" | identity == "West" | identity == "Lynn" )
 
 ###model
 model.3poly = lm(canopy.height ~ no.sites + identity + no.discs, data=mg.spring2017.1month.ch.Poly3)
-anova(model.3poly) # identity --> significant; no.sites(diversity) --> marginally significant; no overyielding
+anova(model.3poly) # identity and no.sites --> significant; no overyielding
 plot(canopy.height ~ no.sites, data = mg.spring2017.1month.ch.Poly3)
 plot(canopy.height ~ identity, data = mg.spring2017.1month.den.Poly3)
 ```


### PR DESCRIPTION
Forest updated spring analyses-
      Changed 3 poly mono combination; removed Nahant, added Lynn

# **Results Summary Update:**
## **Shoot Density**
_In spring_, **poly5s** had significantly fewer shoots per disc than mean mono. **Poly3s** also had significantly fewer shoots per disc than mean mono.

## **Canopy Height**
_In spring_, **poly5s** had significantly taller canopies than the mean mono, but poly5 canopy height was not greater than mono with tallest canopy (West Beach, Nahant). **Poly3s** also had significantly taller canopies than the mean mono, but poly3 canopy height was not taller than the mono with the tallest canopy (West Beach).